### PR TITLE
Raster CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ To launch the app use:
 
 `python -m tsbrowse serve /path/to/tsbrowse-file`
 
+Or to generate a PNG of a specific page use, e.g:
+
+`python -m tsbrowse screenshot /path/to/tsbrowse-file mutations`
+
 On WSL, it may be necessary to disable Numba's CUDA support:
 
 `NUMBA_DISABLE_CUDA=1 python -m tsbrowse serve /path/to/tsbrowse-file`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import os
 
 import tszip
 from click.testing import CliRunner
+from PIL import Image
 
 from . import test_preprocess
 from tsbrowse import __main__ as main
@@ -29,3 +30,51 @@ def test_preprocess_cli(tmpdir):
     tszip.load(custom_output_path).tables.assert_equals(ts.tables)
 
     # TODO Load into model and check that the model is correct
+
+
+def test_screenshot_cli(tmpdir):
+    tszip_path = os.path.join(tmpdir, "test_input.tszip")
+    tsbrowse_path = os.path.join(tmpdir, "test_input.tsbrowse")
+    ts = test_preprocess.single_tree_example_ts()
+    tszip.compress(ts, tszip_path)
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["preprocess", tszip_path])
+    assert result.exit_code == 0
+
+    # Test with default output
+    result = runner.invoke(main.cli, ["screenshot", tsbrowse_path, "overview"])
+    assert result.exit_code == 0
+    default_output = os.path.join(tmpdir, "test_input_overview.png")
+    assert os.path.exists(default_output)
+    with Image.open(default_output) as img:
+        width, height = img.size
+        assert width == 1920
+        assert height == 1080
+
+    # Test with custom dimensions and path
+    custom_output = os.path.join(tmpdir, "custom_screenshot.png")
+    result = runner.invoke(
+        main.cli,
+        [
+            "screenshot",
+            tsbrowse_path,
+            "edge_explorer",
+            "--output",
+            custom_output,
+            "--width",
+            "1920",
+            "--height",
+            "1080",
+        ],
+    )
+    assert result.exit_code == 0
+    assert os.path.exists(custom_output)
+    with Image.open(custom_output) as img:
+        width, height = img.size
+        assert width == 1920
+        assert height == 1080
+
+    # Test with invalid page
+    result = runner.invoke(main.cli, ["screenshot", tsbrowse_path, "InvalidPage"])
+    assert result.exit_code != 0
+    assert "Invalid value" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,8 +29,6 @@ def test_preprocess_cli(tmpdir):
     assert os.path.exists(custom_output_path)
     tszip.load(custom_output_path).tables.assert_equals(ts.tables)
 
-    # TODO Load into model and check that the model is correct
-
 
 def test_screenshot_cli(tmpdir):
     tszip_path = os.path.join(tmpdir, "test_input.tszip")

--- a/tsbrowse/__main__.py
+++ b/tsbrowse/__main__.py
@@ -16,6 +16,7 @@ from . import model  # noqa
 from . import pages  # noqa
 from . import config  # noqa
 from . import preprocess as preprocess_  # noqa
+from . import raster  # noqa
 
 logger = daiquiri.getLogger("tsbrowse")
 
@@ -171,6 +172,48 @@ def preprocess(tszip_path, output):
     preprocess_.preprocess(tszip_path, output, show_progress=True)
     logger.info(f"Preprocessing completed. Output saved to: {output}")
     print(f"Preprocessing completed. You can now view with `tsbrowse serve {output}`")
+
+
+@cli.command()
+@click.argument("tsbrowse_path", type=click.Path(exists=True, dir_okay=False))
+@click.argument(
+    "page",
+    type=click.Choice(
+        [page.__name__.split(".")[-1] for page in pages.PAGES_MAP.values()]
+    ),
+)
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="Optional output filename for the screenshot. If not provided, it will"
+    "be automatically generated based on the input filename and page name.",
+)
+@click.option(
+    "--width", type=int, default=1920, help="Width of the screenshot in pixels"
+)
+@click.option(
+    "--height", type=int, default=1080, help="Height of the screenshot in pixels"
+)
+def screenshot(tsbrowse_path, page, output, width, height):
+    """
+    Create a screenshot of a specific page from a .tsbrowse file.
+
+    TSBROWSE_PATH: Path to the .tsbrowse file to screenshot.
+
+    PAGE: The specific page to capture (e.g., 'overview', 'mutations', 'edges').
+
+    Example usage:
+    tsbrowse screenshot example.tsbrowse overview --output outfile.png
+    """
+    if output is None:
+        base_name = tsbrowse_path.rsplit(".", 1)[0]
+        output = f"{base_name}_{page}.png"
+
+    raster.raster_component(
+        getattr(pages, page).page, tsbrowse_path, output, width=width, height=height
+    )
+    logger.info(f"Screenshot saved to: {output}")
 
 
 if __name__ == "__main__":

--- a/tsbrowse/__main__.py
+++ b/tsbrowse/__main__.py
@@ -157,6 +157,7 @@ def serve(path, port, show, log_level, no_log_filter, annotations_file):
 @click.argument("tszip_path", type=click.Path(exists=True, dir_okay=False))
 @click.option(
     "--output",
+    "-o",
     type=click.Path(dir_okay=False),
     default=None,
     help="Optional output filename, defaults to tszip_path with .tsbrowse extension",
@@ -184,6 +185,7 @@ def preprocess(tszip_path, output):
 )
 @click.option(
     "--output",
+    "-o",
     type=click.Path(dir_okay=False),
     default=None,
     help="Optional output filename for the screenshot. If not provided, it will"


### PR DESCRIPTION
Fixes #161 

Add a `tsbrowse screenshot` command to generate a PNG of a specific page.