### PR TITLE
Add metadata to tables, fix slow start

### DIFF
--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -83,7 +83,7 @@ def test_model(tmpdir):
 
     assert len(tsm.populations_df) == ts.num_populations
     for m1, m2 in zip(ts.populations(), tsm.populations_df.to_dict("records")):
-        assert m1.metadata == m2["metadata"]
+        assert str(m1.metadata) == m2["metadata"]
 
     assert len(tsm.migrations_df) == ts.num_migrations
     for col in ["left", "right", "node", "source", "dest", "time"]:

--- a/tsbrowse/pages/tables.py
+++ b/tsbrowse/pages/tables.py
@@ -11,6 +11,7 @@ WANTED_COLUMNS = {
         "span",
         "parent_time",
         "child_time",
+        "metadata",
     ],
     "trees": [
         "id",
@@ -34,6 +35,7 @@ WANTED_COLUMNS = {
         "num_descendants",
         "num_inheritors",
         "inherited_state",
+        "metadata",
     ],
     "nodes": [
         "id",
@@ -43,11 +45,12 @@ WANTED_COLUMNS = {
         "individual",
         "num_mutations",
         "ancestors_span",
+        "metadata",
     ],
-    "sites": ["id", "position", "ancestral_state", "num_mutations"],
-    "individuals": ["id", "flags", "parents", "location"],
-    "populations": ["id"],
-    "migrations": ["id", "left", "right", "node", "source", "dest", "time"],
+    "sites": ["id", "position", "ancestral_state", "num_mutations", "metadata"],
+    "individuals": ["id", "flags", "parents", "location", "metadata"],
+    "populations": ["id", "metadata"],
+    "migrations": ["id", "left", "right", "node", "source", "dest", "time", "metadata"],
     "provenances": ["id", "timestamp", "record"],
 }
 


### PR DESCRIPTION
Whilst working on other things and testing with a large TS I noticed that we are objectifying all the mutations several times. This means for a large TS start up can take way too long. I've reworked the loading code to not use the tskit row objects. Hopefully this is a good compromise. I've also added metadata to the table views.