### PR TITLE
Add range control to plot

### DIFF
--- a/tsbrowse/plot_helpers.py
+++ b/tsbrowse/plot_helpers.py
@@ -19,19 +19,20 @@ def filter_points(points, x_range, y_range):
     return points
 
 
-def make_hist_on_axis(dimension, points):
+def make_hist_on_axis(dimension, points, x_range=None):
     """
     Make histogram function for a specified axis of a scatter plot
     """
 
     def compute_hist(x_range, y_range):
         filtered_points = filter_points(points, x_range, y_range)
+        opts = {} if x_range is None else {"xlim": x_range}
         hist = hv.operation.histogram(
             filtered_points,
             dimension=dimension,
             bins="auto",
             normed="height",
-        )
+        ).opts(**opts)
         return hist
 
     return compute_hist
@@ -99,3 +100,11 @@ def customise_ticks(plot, element):
 
 def center_plot_title(plot, element):
     plot.state.title.align = "center"
+
+
+def parse_range(range_str):
+    try:
+        start, end = map(float, range_str.split(":"))
+        return (start, end)
+    except (ValueError, TypeError):
+        return None


### PR DESCRIPTION
Closes #198 

I've spent too much time trying to get bidirectional binding working here without any luck. So for now the scrolling on the plot doesn't update the control. Annoyingly I can get it to work in a toy example:

```python
import panel as pn
import holoviews as hv
import hvplot.pandas
import numpy as np
import pandas as pd

pn.extension()
hv.extension('bokeh')

x = np.linspace(0, 100, 1000)
y = np.sin(x/10) + np.random.randn(len(x))*0.1
df = pd.DataFrame({'x': x, 'y': y})

x_range = pn.widgets.TextInput(value='0:100', name='X Range (start:stop)')

def parse_range(range_str):
    try:
        start, end = map(float, range_str.split(':'))
        return (start, end)
    except (ValueError, TypeError):
        return (0, 100)  # Default range if parsing fails

def get_plot(range_str):
    x_range = parse_range(range_str)
    return df.hvplot.line(x='x', y='y').opts(xlim=x_range, framewise=True)

dmap = hv.DynamicMap(pn.bind(get_plot, x_range))

range_stream = hv.streams.RangeX(source=dmap)

def update_widget(event):
    if event.new is not None:
        new_start, new_end = event.new
        new_value = f"{new_start}:{new_end}"
        if new_value != x_range.value:
            x_range.value = new_value

range_stream.param.watch(update_widget, 'x_range')

pn.Column(x_range, dmap).servable()
```