### PR TITLE
Change Y axis label

### DIFF
--- a/tsbrowse/pages/mutations.py
+++ b/tsbrowse/pages/mutations.py
@@ -44,9 +44,9 @@ def make_muts_panel(log_y, tsm):
         clabel="inheritors",
         tools=[hover_tool, "tap"],
         xlabel="Position",
-        ylabel=f"Time ({tsm.ts.time_units})"
+        ylabel=f"Mutation time ({tsm.ts.time_units})"
         if not log_y
-        else f"Log (Time ({tsm.ts.time_units}))",
+        else f"Log (Mutation time ({tsm.ts.time_units}))",
     )
 
     range_stream = hv.streams.RangeXY(source=points)


### PR DESCRIPTION
I think it is helpful to say "Mutation time" rather than just "Time", because that's an additional cue that we are looking at the mutations pane rather than e.g. the edges pane, for new users