### PR TITLE
Update changelog for maint release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## [0.0.4] - 2025-09-18
+## [0.1.0] - 2026-02-05
+
+Maintenance release.
 
 - Support Python3.10-3.13 (#256)
+- Add explicit pins for Zarr<3
 
 ## [0.0.3] - 2025-06-11
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ Documentation: https://tskit.dev/tsbrowse/docs/stable/ (latest: https://tskit.de
 
 It is particularly useful to help evaluate ARGs that have been inferred using tools such as
 [tsinfer](https://github.com/tskit-dev/tsinfer),
-[sc2ts](https://github.com/jeromekelleher/sc2ts),
+[sc2ts](https://github.com/tskit-dev/sc2ts),
 [Relate](https://github.com/MyersGroup/relate),
-[KwARG](https://github.com/a-ignatieva/kwarg),
 [Threads](https://pypi.org/project/threads-arg/), etc.
 
 ## Quickstart


### PR DESCRIPTION
Turns out 0.0.4 was never actually released on PyPi so deleting that entry.

Bumping version to 0.1.0 as being on the 0.0 series seems unnecessary given that we're not planning on doing a lot of development on this.